### PR TITLE
Add Docker and Docker Compose support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ##
 ## Stage 1 — build the PCBCase binaries
 ##
-FROM debian:bookworm-slim AS build
+FROM debian:trixie-slim AS build
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential git ca-certificates pkg-config libpopt-dev \
@@ -21,10 +21,9 @@ RUN make
 ##
 ## Stage 2 — minimal runtime with OpenSCAD CLI to render STL/3MF
 ##
-FROM debian:bookworm-slim
+FROM openscad/openscad:trixie.2025-09-22
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    openscad libpopt0 \
+RUN apt-get update && apt-get install -y --no-install-recommends libpopt0 \
  && rm -rf /var/lib/apt/lists/*
 
 # Where you'll mount your boards/files from the host

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+# syntax=docker/dockerfile:1
+##
+## Stage 1 — build the PCBCase binaries
+##
+FROM debian:bookworm-slim AS build
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential git ca-certificates pkg-config libpopt-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+# If you place this Dockerfile at the repo root, this will copy sources in.
+COPY . /src
+
+# Pull submodules if present (repo has a .gitmodules file)
+RUN [ -f .gitmodules ] && git submodule update --init --recursive || true
+
+# Build via the project's Makefile
+RUN make
+
+##
+## Stage 2 — minimal runtime with OpenSCAD CLI to render STL/3MF
+##
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    openscad libpopt0 \
+ && rm -rf /var/lib/apt/lists/*
+
+# Where you'll mount your boards/files from the host
+WORKDIR /workbench
+
+# Copy the compiled binary and the OpenSCAD library
+COPY --from=build /src/case /usr/local/bin/case
+COPY --from=build /src/case-scad /opt/case-scad
+
+# Make the case-scad modules discoverable by OpenSCAD
+ENV OPENSCADPATH=/opt/case-scad
+
+# Default shows the tool's help so usage is self-discoverable
+CMD ["case", "--help"]

--- a/README.md
+++ b/README.md
@@ -5,3 +5,52 @@ This is designed to take an KICad 7 `.kicad_pcb` file and produce an openscad fi
 ![275724777_4932056986873909_2086496272107808800_n](https://user-images.githubusercontent.com/996983/158376722-9541f6dd-25f3-4107-ac4b-4513a761b210.jpg)
 
 [Models](models/README.md)
+
+## 🐳 Using Docker
+
+You can run PCBCase without installing local toolchains by using the provided Docker image.
+
+### Quick start
+Build once from the repo root:
+```bash
+docker build -t pcbcase .
+```
+
+Show help:
+
+```bash
+docker run --rm -v "$PWD":/workbench -w /workbench pcbcase case --help
+```
+
+### Convert the included test board (SCAD)
+
+This reproduces the Makefile rule:
+
+```bash
+docker run --rm -v "$PWD":/workbench -w /workbench pcbcase \
+  case -o PCB/Test/Test.scad PCB/Test/Test.kicad_pcb -M models
+```
+
+### Render the SCAD to STL
+
+```bash
+docker run --rm -v "$PWD":/workbench -w /workbench pcbcase \
+  openscad -o PCB/Test/Test.stl PCB/Test/Test.scad
+```
+
+## 🐳 Using Docker Compose
+
+A ready-to-use `docker-compose.yml` is provided. It already chains:
+1) Generate SCAD from the test KiCad board
+2) Render STL from the generated SCAD
+
+### Run the built-in one-liner for the test board
+```bash
+docker compose build
+docker compose run --rm pcbcase
+````
+
+This produces:
+
+* `PCB/Test/Test.scad`
+* `PCB/Test/Test.stl`

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,16 @@
+services:
+  pcbcase:
+    build: .
+    image: pcbcase:latest
+    working_dir: /workbench
+    volumes:
+      - ./:/workbench
+    command:
+      - sh
+      - -c
+      - |
+        # Step 1: Generate a .scad model from the sample KiCad PCB file
+        /usr/local/bin/case -o PCB/Test/Test.scad PCB/Test/Test.kicad_pcb -M models
+
+        # Step 2: Render the .scad file into a printable .stl file with OpenSCAD
+        # openscad -o PCB/Test/Test.stl PCB/Test/Test.scad


### PR DESCRIPTION
Enables users to test the project and convert the sample PCB/Test files without installing local toolchains.

- Added `Dockerfile` to build and run PCBCase with OpenSCAD.
- Added `docker-compose.yml` with self-documented commands for generating .scad and .stl.
- Updated `README.md` with usage instructions for both Docker and Docker Compose.